### PR TITLE
Fix plan and skipping in t/util-type-date.t (RT123089)

### DIFF
--- a/t/util-type-date.t
+++ b/t/util-type-date.t
@@ -14,26 +14,27 @@ for my $mod (@datemods) {
     $mod_available{$mod} = eval "require $mod; 1" ? 1:0;
 }
 
+plan tests => scalar @datemods;
 for my $mod (@datemods) {
-    plan skip_all => "$mod not available" unless $mod_available{$mod};
+    SKIP: {
+        skip "$mod not available", 1 unless $mod_available{$mod};
 
-    local $Data::Sah::Util::Type::Date::DATE_MODULE = $mod;
+        local $Data::Sah::Util::Type::Date::DATE_MODULE = $mod;
 
-    subtest "coerce_date ($mod)" => sub {
-        ok(!defined(coerce_date(undef)));
-        ok(!defined(coerce_date("x")));
-        ok(!defined(coerce_date(100_000)));
-        ok(!defined(coerce_date(3_000_000_000)));
-        #ok(!defined(coerce_date("2014-04-31"))); # Time::Piece accepts this
-        ok(!defined(coerce_date("2014-04-32")));
+        subtest "coerce_date ($mod)" => sub {
+            ok(!defined(coerce_date(undef)));
+            ok(!defined(coerce_date("x")));
+            ok(!defined(coerce_date(100_000)));
+            ok(!defined(coerce_date(3_000_000_000)));
+            #ok(!defined(coerce_date("2014-04-31"))); # Time::Piece accepts this
+            ok(!defined(coerce_date("2014-04-32")));
 
-        is( ref(coerce_date("2014-04-25")), $mod);
-        is( ref(coerce_date("2014-04-25T10:20:30Z")), $mod);
-        is( ref(coerce_date(100_000_000)), $mod);
-        is( ref(coerce_date(DateTime->now)), $mod) if $mod_available{DateTime};
-        is( ref(coerce_date(Time::Moment->now)), $mod) if $mod_available{'Time::Moment'};
-        is( ref(coerce_date(scalar Time::Piece->gmtime)), $mod) if $mod_available{'Time::Piece'};
-    };
+            is( ref(coerce_date("2014-04-25")), $mod);
+            is( ref(coerce_date("2014-04-25T10:20:30Z")), $mod);
+            is( ref(coerce_date(100_000_000)), $mod);
+            is( ref(coerce_date(DateTime->now)), $mod) if $mod_available{DateTime};
+            is( ref(coerce_date(Time::Moment->now)), $mod) if $mod_available{'Time::Moment'};
+            is( ref(coerce_date(scalar Time::Piece->gmtime)), $mod) if $mod_available{'Time::Piece'};
+        };
+    }
 }
-
-done_testing;


### PR DESCRIPTION
This patch fixes [RT123089](https://rt.cpan.org/Public/Bug/Display.html?id=123089). In case one of the tested date modules is not available, skip_all caused a bad plan error. With this change, each module subtest is skipped separately.

Done as part of the CPAN Pull Request Challenge.