### PR TITLE
fix exit status

### DIFF
--- a/devscripts/list-missing-translations
+++ b/devscripts/list-missing-translations
@@ -32,4 +32,4 @@ for my $k (@kxlt1) {
     say "q[", backslash($_), "]";
 }
 
-exit $found ? 1:0;
+exit($found ? 1 : 0);


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $found ? 1:0` parses as `(exit $found) ? 1 : 0`, which is not what was intended.